### PR TITLE
Clarify threshold for frontier and update vignette

### DIFF
--- a/R/frontier.R
+++ b/R/frontier.R
@@ -5,13 +5,12 @@
 #' Solutions are filtered so that no remaining option has higher cost and
 #' lower or equal impact than another. After finding these dominant
 #' solutions an optional `threshold` removes any that cost more per unit
-#' impact than the specified value.
+#' impact gained than the specified value.
 #'
 #' @param x Data frame containing `cost` and `impact` columns.
-#' @param threshold Optional numeric value describing the allowed
-#'   cost effectiveness. After identifying the frontier, solutions with
-#'   `impact / cost` below this value are discarded (or `cost / impact`
-#'   above it when `maximise = FALSE`).
+#' @param threshold Optional numeric value describing the allowed cost per
+#'   unit of impact gained. After identifying the frontier, solutions with
+#'   `cost / impact` above this value are discarded.
 #' @param keep_all Logical, if `TRUE` return all supplied rows with an added
 #'   logical column `frontier`. Otherwise only frontier rows are returned.
 #' @param maximise Logical, if `TRUE` (default) the frontier is calculated
@@ -26,7 +25,7 @@
 #'                  impact = c(1, 1.5, 2, 2.4))
 #' frontier(df)
 #' frontier(df, keep_all = TRUE)
-#' frontier(df, threshold = 1)
+#' frontier(df, threshold = 1) # maximum cost per unit impact
 #' frontier(df, maximise = FALSE)
 frontier <- function(x, threshold = NULL, keep_all = FALSE, maximise = TRUE) {
   if (!is.data.frame(x)) {
@@ -63,8 +62,8 @@ frontier <- function(x, threshold = NULL, keep_all = FALSE, maximise = TRUE) {
   sorted$frontier <- keep_frontier
 
   if (!is.null(threshold)) {
-    ratio <- if (maximise) sorted$impact / sorted$cost else sorted$cost / sorted$impact
-    threshold_keep <- if (maximise) ratio >= threshold else ratio <= threshold
+    ratio <- sorted$cost / sorted$impact
+    threshold_keep <- ratio <= threshold
     sorted$threshold <- threshold_keep
   }
 

--- a/tests/testthat/test-frontier.R
+++ b/tests/testthat/test-frontier.R
@@ -35,7 +35,7 @@ test_that("threshold with keep_all returns filter column", {
   )
   res <- frontier(df, threshold = 1.5, keep_all = TRUE)
   expect_true("threshold" %in% names(res))
-  expect_equal(res$threshold, res$impact / res$cost >= 1.5)
+  expect_equal(res$threshold, res$cost / res$impact <= 1.5)
 })
 
 test_that("maximise = FALSE finds lower frontier", {

--- a/vignettes/frontier.Rmd
+++ b/vignettes/frontier.Rmd
@@ -20,9 +20,12 @@ library(om)
 
 This vignette demonstrates how to find the cost-effectiveness frontier using
 `frontier()`. We'll create a small simulated data set with cost and impact
-values and then highlight the solutions that lie on the frontier. We'll also
-apply a threshold to remove options that cost more than the allowed
-cost-per-impact.
+values and then highlight the solutions that lie on the frontier. We also apply
+a *threshold* that limits the maximum cost per unit of impact gained. The World
+Health Organization suggests that interventions costing up to 1–3 times a
+country's GDP per capita for each disability-adjusted life year (DALY) gained
+are often considered cost-effective. In our generic example this simply means
+setting an upper limit on the cost divided by impact.
 
 ```{r}
 set.seed(1)
@@ -59,23 +62,19 @@ frontier(example, threshold = thres)
 
 ## Minimising an outcome
 
-Sometimes the quantity of interest is something we want to reduce, such as the number of cases. Set `maximise = FALSE` and `frontier()` will return the lower frontier. We can also supply a *threshold* giving the maximum cost per case we are willing to pay. Any frontier points above this line are filtered out, which we mark in red below.
+Sometimes the quantity of interest is something we want to reduce, such as the number of cases. Set `maximise = FALSE` and `frontier()` will return the lower frontier. In this example we simply highlight the points that sit on that frontier.
 
 ```{r}
 example_cases <- data.frame(cost = example$cost,
                             cases = 30 - example$impact)
 example_cases$impact <- example_cases$cases
-case_thres <- 0.6
 front_cases <- frontier(example_cases,
                         keep_all = TRUE,
-                        maximise = FALSE,
-                        threshold = case_thres)
-cols2 <- c(Frontier = "blue", Other = "grey70", Filtered = "red")
-status2 <- ifelse(!front_cases$threshold, "Filtered",
-                  ifelse(front_cases$frontier, "Frontier", "Other"))
+                        maximise = FALSE)
+cols2 <- c(Frontier = "blue", Other = "grey70")
+status2 <- ifelse(front_cases$frontier, "Frontier", "Other")
 plot(front_cases$cost, front_cases$impact,
      col = cols2[status2], pch = 16,
      xlab = "Cost", ylab = "Cases")
-abline(a = 0, b = 1 / case_thres, lty = 2)
 legend("topright", legend = names(cols2), col = cols2, pch = 16)
 ```


### PR DESCRIPTION
## Summary
- document the frontier threshold as maximum cost per unit impact gained
- implement cost/impact threshold calculation in `frontier()`
- adjust unit tests for the new definition
- clarify threshold usage in the vignette and remove threshold from the minimisation example

## Testing
- `devtools::document()` *(fails: command not found)*
- `devtools::test()` *(fails: command not found)*
- `devtools::check()` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e19985b0c8326b75d0389b8cc39b9